### PR TITLE
feature: add `monitor` command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,13 @@ enum Commands {
         #[arg(short, long)]
         source_name: String,
     },
+
+    /// Monitor incoming MIDI messages.
+    Monitor {
+        /// Input port name
+        #[arg(short, long)]
+        source_name: String,
+    },
 }
 
 #[derive(Debug)]
@@ -58,7 +65,10 @@ fn main() -> Result<(), Errors> {
             source_name,
             target_name,
         } => {
-            devices.route(source_name.to_string(), target_name.to_string())?;
+            devices.route(source_name, target_name)?;
+        }
+        Commands::Monitor { source_name } => {
+            devices.monitor(source_name)?;
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,10 @@ enum Commands {
         /// Input port name
         #[arg(short, long)]
         source_name: String,
+
+        /// Also print messages sent to the output.
+        #[arg(short, long)]
+        verbose: bool,
     },
 
     /// Monitor incoming MIDI messages.
@@ -40,7 +44,7 @@ pub enum Errors {
     InitFailure,
     InvalidInputPort(String),
     InvalidOutputPort(String),
-    ForwardingError,
+    ForwardingError(String),
 }
 
 impl Display for Errors {
@@ -49,7 +53,9 @@ impl Display for Errors {
             Errors::InitFailure => write!(f, "Failed to initialize MIDI devices"),
             Errors::InvalidInputPort(port) => write!(f, "Invalid input port: {}", port),
             Errors::InvalidOutputPort(port) => write!(f, "Invalid output port: {}", port),
-            Errors::ForwardingError => write!(f, "Failed to forward MIDI messages"),
+            Errors::ForwardingError(message) => {
+                write!(f, "Failed to forward MIDI messages: {}", message)
+            }
         }
     }
 }
@@ -64,8 +70,9 @@ fn main() -> Result<(), Errors> {
         Commands::Route {
             source_name,
             target_name,
+            verbose,
         } => {
-            devices.route(source_name, target_name)?;
+            devices.route(source_name, target_name, verbose)?;
         }
         Commands::Monitor { source_name } => {
             devices.monitor(source_name)?;

--- a/src/midi/devices.rs
+++ b/src/midi/devices.rs
@@ -1,5 +1,4 @@
-use midir::{Ignore, MidiInput, MidiInputPort, MidiOutput, MidiOutputPort};
-use std::error::Error;
+use midir::{Ignore, MidiInput, MidiInputPort, MidiOutput, MidiOutputConnection, MidiOutputPort};
 use std::io::stdin;
 
 use crate::Errors;
@@ -9,9 +8,122 @@ pub struct Devices {
     output: MidiOutput,
 }
 
+trait Outgoing: Send {
+    fn send(&mut self, message: &[u8]) -> Result<(), String>;
+}
+
+trait Target {
+    fn describe(&self, output: &MidiOutput) -> Result<Option<String>, Errors>;
+    fn connect(
+        self: Box<Self>,
+        output: &mut MidiOutputPool,
+    ) -> Result<Box<dyn Outgoing + Send>, Errors>;
+}
+
+struct OutputTarget {
+    port: MidiOutputPort,
+}
+
+impl OutputTarget {
+    fn new(port: MidiOutputPort) -> Self {
+        Self { port }
+    }
+}
+
+impl Target for OutputTarget {
+    fn describe(&self, output: &MidiOutput) -> Result<Option<String>, Errors> {
+        let name = output
+            .port_name(&self.port)
+            .map_err(Devices::forwarding_error)?;
+        Ok(Some(name))
+    }
+
+    fn connect(
+        self: Box<Self>,
+        output: &mut MidiOutputPool,
+    ) -> Result<Box<dyn Outgoing + Send>, Errors> {
+        let midi_out = output.acquire()?;
+        let connection = midi_out
+            .connect(&self.port, "midi-router")
+            .map_err(Devices::forwarding_error)?;
+        Ok(Box::new(MidiOutgoing { connection }))
+    }
+}
+
+struct MonitorTarget {
+    label: &'static str,
+}
+
+impl MonitorTarget {
+    fn new(label: &'static str) -> Self {
+        Self { label }
+    }
+}
+
+impl Target for MonitorTarget {
+    fn describe(&self, _output: &MidiOutput) -> Result<Option<String>, Errors> {
+        Ok(None)
+    }
+
+    fn connect(
+        self: Box<Self>,
+        _output: &mut MidiOutputPool,
+    ) -> Result<Box<dyn Outgoing + Send>, Errors> {
+        Ok(Box::new(MonitorOutgoing::new(self.label)))
+    }
+}
+
+struct MidiOutgoing {
+    connection: MidiOutputConnection,
+}
+
+impl Outgoing for MidiOutgoing {
+    fn send(&mut self, message: &[u8]) -> Result<(), String> {
+        self.connection
+            .send(message)
+            .map_err(|e| format!("{:?}", e))
+    }
+}
+
+struct MonitorOutgoing {
+    label: &'static str,
+}
+
+impl MonitorOutgoing {
+    fn new(label: &'static str) -> Self {
+        Self { label }
+    }
+}
+
+impl Outgoing for MonitorOutgoing {
+    fn send(&mut self, message: &[u8]) -> Result<(), String> {
+        println!("{} message: {:?}", self.label, message);
+        Ok(())
+    }
+}
+
+struct MidiOutputPool {
+    output: Option<MidiOutput>,
+}
+
+impl MidiOutputPool {
+    fn new(output: MidiOutput) -> Self {
+        Self {
+            output: Some(output),
+        }
+    }
+
+    fn acquire(&mut self) -> Result<MidiOutput, Errors> {
+        match self.output.take() {
+            Some(existing) => Ok(existing),
+            None => MidiOutput::new("MIDI Output").map_err(|_| Errors::InitFailure),
+        }
+    }
+}
+
 struct Route {
     pub source: MidiInputPort,
-    pub target: MidiOutputPort,
+    pub targets: Vec<Box<dyn Target>>,
 }
 
 impl Devices {
@@ -29,7 +141,11 @@ impl Devices {
                 println!("Input ports: ");
 
                 self.input.ports().iter().enumerate().for_each(|(i, port)| {
-                    println!("{}: {}", i, self.input.port_name(port).unwrap())
+                    let name = self
+                        .input
+                        .port_name(port)
+                        .unwrap_or_else(|_| "<unknown>".to_string());
+                    println!("{}: {}", i, name)
                 });
             }
         }
@@ -44,73 +160,36 @@ impl Devices {
                     .iter()
                     .enumerate()
                     .for_each(|(i, port)| {
-                        println!("{}: {}", i, self.output.port_name(port).unwrap())
+                        let name = self
+                            .output
+                            .port_name(port)
+                            .unwrap_or_else(|_| "<unknown>".to_string());
+                        println!("{}: {}", i, name)
                     });
             }
         }
     }
 
-    pub fn route(self, source_name: String, target_name: String) -> Result<(), Errors> {
+    pub fn route(
+        self,
+        source_name: String,
+        target_name: String,
+        verbose: bool,
+    ) -> Result<(), Errors> {
+        let source = self
+            .find_input_port(&source_name)
+            .ok_or(Errors::InvalidInputPort(source_name))?;
+
         let target = self
             .find_output_port(&target_name)
             .ok_or(Errors::InvalidOutputPort(target_name))?;
-        let source = self
-            .find_input_port(&source_name)
-            .ok_or(Errors::InvalidInputPort(source_name))?;
 
-        match self.activate(Route { source, target }) {
-            Ok(_) => Ok(()),
-            Err(_) => Err(Errors::ForwardingError),
+        let mut targets: Vec<Box<dyn Target>> = vec![Box::new(OutputTarget::new(target))];
+        if verbose {
+            targets.push(Box::new(MonitorTarget::new("outgoing")));
         }
-    }
-    fn activate(mut self, route: Route) -> Result<(), Box<dyn Error>> {
-        println!("Activating route:");
-        println!("  Input port: {}", self.input.port_name(&route.source)?);
-        println!("  Output port: {}", self.output.port_name(&route.target)?);
 
-        let mut outgoing_connection = self.output.connect(&route.target, "midi-router")?;
-
-        self.input.ignore(Ignore::None);
-
-        // Debug prints in the callback
-        let _connection = self.input.connect(
-            &route.source,
-            "midi-router",
-            move |_stamp, message, _| {
-                // Forward the message
-                if let Err(e) = outgoing_connection.send(message) {
-                    println!("Error sending message: {:?}", e)
-                }
-            },
-            (),
-        )?;
-
-        stdin().read_line(&mut String::new()).ok();
-        Ok(())
-    }
-
-    pub fn monitor(mut self, source_name: String) -> Result<(), Errors> {
-        self.input.ignore(Ignore::None);
-
-        let source = self
-            .find_input_port(&source_name)
-            .ok_or(Errors::InvalidInputPort(source_name))?;
-
-        // Debug prints in the callback
-        let _connection = self
-            .input
-            .connect(
-                &source,
-                "midi-router",
-                move |_stamp, message, _| {
-                    println!("Received message: {:?}", message);
-                },
-                (),
-            )
-            .ok();
-
-        stdin().read_line(&mut String::new()).ok();
-        Ok(())
+        self.activate(Route { source, targets })
     }
 
     fn find_input_port(&self, port_name: &str) -> Option<MidiInputPort> {
@@ -125,5 +204,79 @@ impl Devices {
             .ports()
             .into_iter()
             .find(|port| self.output.port_name(port) == Ok(port_name.to_string()))
+    }
+
+    fn activate(self, route: Route) -> Result<(), Errors> {
+        let input_name = self
+            .input
+            .port_name(&route.source)
+            .map_err(Self::forwarding_error)?;
+
+        let mut output_names: Vec<String> = Vec::new();
+        for target in route.targets.iter() {
+            if let Some(name) = target.describe(&self.output)? {
+                output_names.push(name);
+            }
+        }
+
+        println!("Activating route:");
+        println!("  Input port: {}", input_name);
+        if output_names.is_empty() {
+            println!("  Output port: <none>");
+        } else {
+            println!("  Output port(s): {}", output_names.join(", "));
+        }
+
+        self.connect_route(route)
+    }
+
+    fn forwarding_error<E: std::fmt::Display>(err: E) -> Errors {
+        Errors::ForwardingError(err.to_string())
+    }
+
+    fn connect_route(mut self, route: Route) -> Result<(), Errors> {
+        let mut outgoing_connections: Vec<Box<dyn Outgoing + Send>> = Vec::new();
+        let mut output = MidiOutputPool::new(self.output);
+        for target in route.targets {
+            outgoing_connections.push(target.connect(&mut output)?);
+        }
+
+        self.input.ignore(Ignore::None);
+
+        let _connection = self
+            .input
+            .connect(
+                &route.source,
+                "midi-router",
+                move |_stamp, message, _| {
+                    for connection in outgoing_connections.iter_mut() {
+                        if let Err(e) = connection.send(message) {
+                            println!("Error sending message: {}", e)
+                        }
+                    }
+                },
+                (),
+            )
+            .map_err(Self::forwarding_error)?;
+
+        stdin().read_line(&mut String::new()).ok();
+        Ok(())
+    }
+
+    pub fn monitor(self, source_name: String) -> Result<(), Errors> {
+        let source = self
+            .find_input_port(&source_name)
+            .ok_or(Errors::InvalidInputPort(source_name))?;
+
+        let input_name = self
+            .input
+            .port_name(&source)
+            .map_err(Self::forwarding_error)?;
+        println!("Monitoring input port: {}", input_name);
+
+        self.connect_route(Route {
+            source,
+            targets: vec![Box::new(MonitorTarget::new("incoming"))],
+        })
     }
 }

--- a/src/midi/devices.rs
+++ b/src/midi/devices.rs
@@ -58,9 +58,7 @@ impl Devices {
             .find_input_port(&source_name)
             .ok_or(Errors::InvalidInputPort(source_name))?;
 
-        let route = Route { source, target };
-
-        match self.activate(route) {
+        match self.activate(Route { source, target }) {
             Ok(_) => Ok(()),
             Err(_) => Err(Errors::ForwardingError),
         }
@@ -87,7 +85,31 @@ impl Devices {
             (),
         )?;
 
-        stdin().read_line(&mut String::new())?;
+        stdin().read_line(&mut String::new()).ok();
+        Ok(())
+    }
+
+    pub fn monitor(mut self, source_name: String) -> Result<(), Errors> {
+        self.input.ignore(Ignore::None);
+
+        let source = self
+            .find_input_port(&source_name)
+            .ok_or(Errors::InvalidInputPort(source_name))?;
+
+        // Debug prints in the callback
+        let _connection = self
+            .input
+            .connect(
+                &source,
+                "midi-router",
+                move |_stamp, message, _| {
+                    println!("Received message: {:?}", message);
+                },
+                (),
+            )
+            .ok();
+
+        stdin().read_line(&mut String::new()).ok();
         Ok(())
     }
 


### PR DESCRIPTION
Implements a new command for monitor incoming MIDI messages from a selected device.

Monitoring is also available when using the `route` command and activated by passing the `--verbose` flag.

Got help with the refactor from Claude Code.

---

I've made some architectural changes to support extensibility.

To forward a message, you `connect()` to a target device's port, then use the yielded callback to `send()` it messages through the connection.

I wanted monitoring to have the same design, ie. you route to a monitor object and when you send it messages the monitor prints out the MIDI data.

This means decoupling `Route` from midir's MIDI input/output model and introducing a couple of new traits, `Target` and `Outgoing`.

MonitorTarget and MonitorOutgoing are the implementations which print messages to the output. 

OutputTarget and MidiOutgoing are the implementations which wrap midir's API.

Also, `Route` now holds a collection of targets rather than a single one so that we fan out an incoming message to multiple targets. This was my approach to `route`'s new `-v` flag; if passed, the route forwards messages to the target MIDI device and to a monitor.
