### PR TITLE
feature: decode MIDI messages in `monitor`

### DIFF
--- a/src/midi/devices.rs
+++ b/src/midi/devices.rs
@@ -1,135 +1,17 @@
-use midir::{Ignore, MidiInput, MidiInputPort, MidiOutput, MidiOutputConnection, MidiOutputPort};
-use std::io::stdin;
+use midir::{MidiInput, MidiInputPort, MidiOutput, MidiOutputPort};
 
 use crate::Errors;
+use crate::midi::route::Route;
+use crate::midi::target::{MonitorTarget, OutputTarget, Target};
 
 pub struct Devices {
     input: MidiInput,
-    output: MidiOutput,
-}
-
-trait Outgoing: Send {
-    fn send(&mut self, message: &[u8]) -> Result<(), String>;
-}
-
-trait Target {
-    fn describe(&self, output: &MidiOutput) -> Result<Option<String>, Errors>;
-    fn connect(
-        self: Box<Self>,
-        output: &mut MidiOutputPool,
-    ) -> Result<Box<dyn Outgoing + Send>, Errors>;
-}
-
-struct OutputTarget {
-    port: MidiOutputPort,
-}
-
-impl OutputTarget {
-    fn new(port: MidiOutputPort) -> Self {
-        Self { port }
-    }
-}
-
-impl Target for OutputTarget {
-    fn describe(&self, output: &MidiOutput) -> Result<Option<String>, Errors> {
-        let name = output
-            .port_name(&self.port)
-            .map_err(Devices::forwarding_error)?;
-        Ok(Some(name))
-    }
-
-    fn connect(
-        self: Box<Self>,
-        output: &mut MidiOutputPool,
-    ) -> Result<Box<dyn Outgoing + Send>, Errors> {
-        let midi_out = output.acquire()?;
-        let connection = midi_out
-            .connect(&self.port, "midi-router")
-            .map_err(Devices::forwarding_error)?;
-        Ok(Box::new(MidiOutgoing { connection }))
-    }
-}
-
-struct MonitorTarget {
-    label: &'static str,
-}
-
-impl MonitorTarget {
-    fn new(label: &'static str) -> Self {
-        Self { label }
-    }
-}
-
-impl Target for MonitorTarget {
-    fn describe(&self, _output: &MidiOutput) -> Result<Option<String>, Errors> {
-        Ok(None)
-    }
-
-    fn connect(
-        self: Box<Self>,
-        _output: &mut MidiOutputPool,
-    ) -> Result<Box<dyn Outgoing + Send>, Errors> {
-        Ok(Box::new(MonitorOutgoing::new(self.label)))
-    }
-}
-
-struct MidiOutgoing {
-    connection: MidiOutputConnection,
-}
-
-impl Outgoing for MidiOutgoing {
-    fn send(&mut self, message: &[u8]) -> Result<(), String> {
-        self.connection
-            .send(message)
-            .map_err(|e| format!("{:?}", e))
-    }
-}
-
-struct MonitorOutgoing {
-    label: &'static str,
-}
-
-impl MonitorOutgoing {
-    fn new(label: &'static str) -> Self {
-        Self { label }
-    }
-}
-
-impl Outgoing for MonitorOutgoing {
-    fn send(&mut self, message: &[u8]) -> Result<(), String> {
-        println!("{} message: {:?}", self.label, message);
-        Ok(())
-    }
-}
-
-struct MidiOutputPool {
-    output: Option<MidiOutput>,
-}
-
-impl MidiOutputPool {
-    fn new(output: MidiOutput) -> Self {
-        Self {
-            output: Some(output),
-        }
-    }
-
-    fn acquire(&mut self) -> Result<MidiOutput, Errors> {
-        match self.output.take() {
-            Some(existing) => Ok(existing),
-            None => MidiOutput::new("MIDI Output").map_err(|_| Errors::InitFailure),
-        }
-    }
-}
-
-struct Route {
-    pub source: MidiInputPort,
-    pub targets: Vec<Box<dyn Target>>,
 }
 
 impl Devices {
     pub fn new() -> Result<Self, Errors> {
-        match (MidiInput::new("MIDI Input"), MidiOutput::new("MIDI Output")) {
-            (Ok(input), Ok(output)) => Ok(Self { input, output }),
+        match MidiInput::new("MIDI Input") {
+            Ok(input) => Ok(Self { input }),
             _ => Err(Errors::InitFailure),
         }
     }
@@ -150,23 +32,21 @@ impl Devices {
             }
         }
 
-        match self.output.ports().len() {
-            0 => println!("No output ports found."),
-            _ => {
-                println!("Output ports: ");
+        match MidiOutput::new("MIDI Output") {
+            Ok(output) => match output.ports().len() {
+                0 => println!("No output ports found."),
+                _ => {
+                    println!("Output ports: ");
 
-                self.output
-                    .ports()
-                    .iter()
-                    .enumerate()
-                    .for_each(|(i, port)| {
-                        let name = self
-                            .output
+                    output.ports().iter().enumerate().for_each(|(i, port)| {
+                        let name = output
                             .port_name(port)
                             .unwrap_or_else(|_| "<unknown>".to_string());
                         println!("{}: {}", i, name)
                     });
-            }
+                }
+            },
+            _ => println!("Failed to initialize MIDI output."),
         }
     }
 
@@ -180,8 +60,8 @@ impl Devices {
             .find_input_port(&source_name)
             .ok_or(Errors::InvalidInputPort(source_name))?;
 
-        let target = self
-            .find_output_port(&target_name)
+        let output = MidiOutput::new("MIDI Output").map_err(|_| Errors::InitFailure)?;
+        let target = Self::find_output_port(&output, &target_name)
             .ok_or(Errors::InvalidOutputPort(target_name))?;
 
         let mut targets: Vec<Box<dyn Target>> = vec![Box::new(OutputTarget::new(target))];
@@ -189,32 +69,14 @@ impl Devices {
             targets.push(Box::new(MonitorTarget::new("outgoing")));
         }
 
-        self.activate(Route { source, targets })
-    }
-
-    fn find_input_port(&self, port_name: &str) -> Option<MidiInputPort> {
-        self.input
-            .ports()
-            .into_iter()
-            .find(|port| self.input.port_name(port) == Ok(port_name.to_string()))
-    }
-
-    fn find_output_port(&self, port_name: &str) -> Option<MidiOutputPort> {
-        self.output
-            .ports()
-            .into_iter()
-            .find(|port| self.output.port_name(port) == Ok(port_name.to_string()))
-    }
-
-    fn activate(self, route: Route) -> Result<(), Errors> {
         let input_name = self
             .input
-            .port_name(&route.source)
+            .port_name(&source)
             .map_err(Self::forwarding_error)?;
 
         let mut output_names: Vec<String> = Vec::new();
-        for target in route.targets.iter() {
-            if let Some(name) = target.describe(&self.output)? {
+        for target in targets.iter() {
+            if let Some(name) = target.describe(&output)? {
                 output_names.push(name);
             }
         }
@@ -227,40 +89,8 @@ impl Devices {
             println!("  Output port(s): {}", output_names.join(", "));
         }
 
-        self.connect_route(route)
-    }
-
-    fn forwarding_error<E: std::fmt::Display>(err: E) -> Errors {
-        Errors::ForwardingError(err.to_string())
-    }
-
-    fn connect_route(mut self, route: Route) -> Result<(), Errors> {
-        let mut outgoing_connections: Vec<Box<dyn Outgoing + Send>> = Vec::new();
-        let mut output = MidiOutputPool::new(self.output);
-        for target in route.targets {
-            outgoing_connections.push(target.connect(&mut output)?);
-        }
-
-        self.input.ignore(Ignore::None);
-
-        let _connection = self
-            .input
-            .connect(
-                &route.source,
-                "midi-router",
-                move |_stamp, message, _| {
-                    for connection in outgoing_connections.iter_mut() {
-                        if let Err(e) = connection.send(message) {
-                            println!("Error sending message: {}", e)
-                        }
-                    }
-                },
-                (),
-            )
-            .map_err(Self::forwarding_error)?;
-
-        stdin().read_line(&mut String::new()).ok();
-        Ok(())
+        let Devices { input } = self;
+        Route { source, targets }.activate(input, output)
     }
 
     pub fn monitor(self, source_name: String) -> Result<(), Errors> {
@@ -274,9 +104,30 @@ impl Devices {
             .map_err(Self::forwarding_error)?;
         println!("Monitoring input port: {}", input_name);
 
-        self.connect_route(Route {
+        let output = MidiOutput::new("MIDI Output").map_err(|_| Errors::InitFailure)?;
+        let Devices { input } = self;
+        Route {
             source,
             targets: vec![Box::new(MonitorTarget::new("incoming"))],
-        })
+        }
+        .activate(input, output)
+    }
+
+    fn find_input_port(&self, port_name: &str) -> Option<MidiInputPort> {
+        self.input
+            .ports()
+            .into_iter()
+            .find(|port| self.input.port_name(port) == Ok(port_name.to_string()))
+    }
+
+    fn find_output_port(output: &MidiOutput, port_name: &str) -> Option<MidiOutputPort> {
+        output
+            .ports()
+            .into_iter()
+            .find(|port| output.port_name(port) == Ok(port_name.to_string()))
+    }
+
+    fn forwarding_error<E: std::fmt::Display>(err: E) -> Errors {
+        Errors::ForwardingError(err.to_string())
     }
 }

--- a/src/midi/mod.rs
+++ b/src/midi/mod.rs
@@ -1,2 +1,4 @@
 pub mod devices;
+pub mod route;
+pub mod target;
 pub use devices::Devices;

--- a/src/midi/route.rs
+++ b/src/midi/route.rs
@@ -1,0 +1,48 @@
+use midir::{Ignore, MidiInput, MidiInputPort, MidiOutput};
+use std::io::stdin;
+
+use crate::Errors;
+use crate::midi::target::{Outgoing, Target};
+
+pub(crate) struct Route {
+    pub source: MidiInputPort,
+    pub targets: Vec<Box<dyn Target>>,
+}
+
+impl Route {
+    pub(crate) fn activate(self, mut input: MidiInput, output: MidiOutput) -> Result<(), Errors> {
+        let mut outgoing_connections: Vec<Box<dyn Outgoing + Send>> = Vec::new();
+        let mut output = Some(output);
+        for target in self.targets {
+            let midi_out = match output.take() {
+                Some(existing) => existing,
+                None => MidiOutput::new("MIDI Output").map_err(|_| Errors::InitFailure)?,
+            };
+            outgoing_connections.push(target.connect(midi_out)?);
+        }
+
+        input.ignore(Ignore::None);
+
+        let _connection = input
+            .connect(
+                &self.source,
+                "midi-router",
+                move |_stamp, message, _| {
+                    for connection in outgoing_connections.iter_mut() {
+                        if let Err(e) = connection.send(message) {
+                            println!("Error sending message: {}", e)
+                        }
+                    }
+                },
+                (),
+            )
+            .map_err(forwarding_error)?;
+
+        stdin().read_line(&mut String::new()).ok();
+        Ok(())
+    }
+}
+
+fn forwarding_error<E: std::fmt::Display>(err: E) -> Errors {
+    Errors::ForwardingError(err.to_string())
+}

--- a/src/midi/target.rs
+++ b/src/midi/target.rs
@@ -1,7 +1,9 @@
 use midir::{MidiOutput, MidiOutputConnection, MidiOutputPort};
+use std::io::Write;
+use std::sync::mpsc;
+use std::thread;
 
 use crate::Errors;
-
 pub(crate) trait Outgoing: Send {
     fn send(&mut self, message: &[u8]) -> Result<(), String>;
 }
@@ -68,20 +70,112 @@ impl Outgoing for MidiOutgoing {
 }
 
 struct MonitorOutgoing {
-    label: &'static str,
+    tx: mpsc::Sender<Vec<u8>>,
 }
 
 impl MonitorOutgoing {
     fn new(label: &'static str) -> Self {
-        Self { label }
+        let (tx, rx) = mpsc::channel::<Vec<u8>>();
+        let label = label.to_string();
+        thread::spawn(move || {
+            let mut last_len = 0usize;
+            loop {
+                match rx.recv() {
+                    Ok(message) => {
+                        last_len = print_monitor_line(&label, &message, last_len);
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+
+        Self { tx }
     }
 }
 
 impl Outgoing for MonitorOutgoing {
     fn send(&mut self, message: &[u8]) -> Result<(), String> {
-        println!("{} message: {:?}", self.label, message);
+        self.tx.send(message.to_vec()).map_err(|e| e.to_string())?;
         Ok(())
     }
+}
+
+fn decode_message(message: &[u8]) -> String {
+    if message.is_empty() {
+        return "empty message".to_string();
+    }
+
+    let status = message[0];
+    if status == 0xF0 {
+        let preview_len = usize::min(8, message.len());
+        let preview = &message[..preview_len];
+        return format!("SysEx len={} {:?}", message.len(), preview);
+    }
+
+    let (kind, channel) = match status & 0xF0 {
+        0x80 => ("NoteOff", Some((status & 0x0F) + 1)),
+        0x90 => ("NoteOn", Some((status & 0x0F) + 1)),
+        0xA0 => ("PolyPressure", Some((status & 0x0F) + 1)),
+        0xB0 => ("CC", Some((status & 0x0F) + 1)),
+        0xC0 => ("Program", Some((status & 0x0F) + 1)),
+        0xD0 => ("ChannelPressure", Some((status & 0x0F) + 1)),
+        0xE0 => ("PitchBend", Some((status & 0x0F) + 1)),
+        0xF0 => ("System", None),
+        _ => ("Unknown", None),
+    };
+
+    let chan = channel.map(|c| format!(" ch{}", c)).unwrap_or_default();
+    let detail = match status & 0xF0 {
+        0x80 | 0x90 => {
+            let note = message.get(1).copied().unwrap_or(0);
+            let vel = message.get(2).copied().unwrap_or(0);
+            format!(" note={} vel={}", note, vel)
+        }
+        0xA0 => {
+            let note = message.get(1).copied().unwrap_or(0);
+            let pressure = message.get(2).copied().unwrap_or(0);
+            format!(" note={} pressure={}", note, pressure)
+        }
+        0xB0 => {
+            let cc = message.get(1).copied().unwrap_or(0);
+            let value = message.get(2).copied().unwrap_or(0);
+            format!(" {}={}", cc, value)
+        }
+        0xC0 => {
+            let program = message.get(1).copied().unwrap_or(0);
+            format!(" program={}", program)
+        }
+        0xD0 => {
+            let pressure = message.get(1).copied().unwrap_or(0);
+            format!(" pressure={}", pressure)
+        }
+        0xE0 => {
+            let lsb = message.get(1).copied().unwrap_or(0) as i16;
+            let msb = message.get(2).copied().unwrap_or(0) as i16;
+            let value = ((msb << 7) | lsb) - 8192;
+            format!(" value={}", value)
+        }
+        _ => String::new(),
+    };
+
+    format!("{}{}{} {:?}", kind, chan, detail, message)
+}
+
+fn print_monitor_line(label: &str, message: &[u8], last_len: usize) -> usize {
+    let decoded = decode_message(message);
+    let mut line = format!("{}: {}", label, decoded);
+    let max_len = 120usize;
+    if line.len() > max_len {
+        line.truncate(max_len.saturating_sub(3));
+        line.push_str("...");
+    }
+    if line.len() < last_len {
+        let padding = last_len - line.len();
+        line.push_str(&" ".repeat(padding));
+    }
+    print!("\r{}", line);
+    std::io::stdout().flush().ok();
+    line.len()
 }
 
 fn forwarding_error<E: std::fmt::Display>(err: E) -> Errors {

--- a/src/midi/target.rs
+++ b/src/midi/target.rs
@@ -1,0 +1,89 @@
+use midir::{MidiOutput, MidiOutputConnection, MidiOutputPort};
+
+use crate::Errors;
+
+pub(crate) trait Outgoing: Send {
+    fn send(&mut self, message: &[u8]) -> Result<(), String>;
+}
+
+pub(crate) trait Target {
+    fn describe(&self, output: &MidiOutput) -> Result<Option<String>, Errors>;
+    fn connect(self: Box<Self>, output: MidiOutput) -> Result<Box<dyn Outgoing + Send>, Errors>;
+}
+
+pub(crate) struct OutputTarget {
+    port: MidiOutputPort,
+}
+
+impl OutputTarget {
+    pub(crate) fn new(port: MidiOutputPort) -> Self {
+        Self { port }
+    }
+}
+
+impl Target for OutputTarget {
+    fn describe(&self, output: &MidiOutput) -> Result<Option<String>, Errors> {
+        let name = output.port_name(&self.port).map_err(forwarding_error)?;
+        Ok(Some(name))
+    }
+
+    fn connect(self: Box<Self>, output: MidiOutput) -> Result<Box<dyn Outgoing + Send>, Errors> {
+        let connection = output
+            .connect(&self.port, "midi-router")
+            .map_err(forwarding_error)?;
+        Ok(Box::new(MidiOutgoing { connection }))
+    }
+}
+
+pub(crate) struct MonitorTarget {
+    label: &'static str,
+}
+
+impl MonitorTarget {
+    pub(crate) fn new(label: &'static str) -> Self {
+        Self { label }
+    }
+}
+
+impl Target for MonitorTarget {
+    fn describe(&self, _output: &MidiOutput) -> Result<Option<String>, Errors> {
+        Ok(None)
+    }
+
+    fn connect(self: Box<Self>, _output: MidiOutput) -> Result<Box<dyn Outgoing + Send>, Errors> {
+        Ok(Box::new(MonitorOutgoing::new(self.label)))
+    }
+}
+
+struct MidiOutgoing {
+    connection: MidiOutputConnection,
+}
+
+impl Outgoing for MidiOutgoing {
+    fn send(&mut self, message: &[u8]) -> Result<(), String> {
+        self.connection
+            .send(message)
+            .map_err(|e| format!("{:?}", e))
+    }
+}
+
+struct MonitorOutgoing {
+    label: &'static str,
+}
+
+impl MonitorOutgoing {
+    fn new(label: &'static str) -> Self {
+        Self { label }
+    }
+}
+
+impl Outgoing for MonitorOutgoing {
+    fn send(&mut self, message: &[u8]) -> Result<(), String> {
+        println!("{} message: {:?}", self.label, message);
+        Ok(())
+    }
+}
+
+fn forwarding_error<E: std::fmt::Display>(err: E) -> Errors {
+    Errors::ForwardingError(err.to_string())
+}


### PR DESCRIPTION
The monitoring code was just printing tuples which wasn't very informative; decode and print them in human-readable...er format.

Architecturally, I'm also starting to simplify the `Devices` module.

Coming from a OO-focused mindset, I thought it'd make sense to have a `Devices` struct to hold on to instances of `midir`'s `MidiInput` and `MidiOutput`. Then you could go through `Devices::route()` to route MIDI traffic using the shared instances.

The "factory pattern" (such as it is) forces me to deal with transfers and lifetimes, which I'm still wrapping my head around.

So I'm moving away from that in favor of initializing the `midir` structs directly where needed.

