### PR TITLE
fix: improve error output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -42,8 +42,8 @@ enum Commands {
 #[derive(Debug)]
 pub enum Errors {
     InitFailure,
-    InvalidInputPort(String),
-    InvalidOutputPort(String),
+    InvalidSourcePort(String),
+    InvalidTargetPort(String),
     ForwardingError(String),
 }
 
@@ -51,8 +51,8 @@ impl Display for Errors {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Errors::InitFailure => write!(f, "Failed to initialize MIDI devices"),
-            Errors::InvalidInputPort(port) => write!(f, "Invalid input port: {}", port),
-            Errors::InvalidOutputPort(port) => write!(f, "Invalid output port: {}", port),
+            Errors::InvalidSourcePort(port) => write!(f, "Invalid source port: {}", port),
+            Errors::InvalidTargetPort(port) => write!(f, "Invalid target port: {}", port),
             Errors::ForwardingError(message) => {
                 write!(f, "Failed to forward MIDI messages: {}", message)
             }
@@ -60,16 +60,21 @@ impl Display for Errors {
     }
 }
 
-fn main() -> Result<(), Errors> {
+fn main() -> std::process::ExitCode {
     let args = Args::parse();
 
-    match args.command {
+    if let Err(e) = match args.command {
         Commands::List => devices::print(),
         Commands::Route {
             source_name,
             target_name,
             verbose,
         } => devices::route(source_name, target_name, verbose),
-        Commands::Monitor { source_name } => devices::monitor(source_name),
+        Commands::Monitor { source } => devices::monitor(source),
+    } {
+        eprintln!("{}", e);
+        return std::process::ExitCode::FAILURE;
     }
+
+    std::process::ExitCode::SUCCESS
 }

--- a/src/midi/devices.rs
+++ b/src/midi/devices.rs
@@ -8,7 +8,7 @@ pub fn print() -> Result<(), Errors> {
     let input = MidiInput::new("midi-tool").map_err(|_| Errors::InitFailure)?;
     let output = MidiOutput::new("midi-tool").map_err(|_| Errors::InitFailure)?;
 
-    if input.ports().len() == 0 {
+    if input.ports().is_empty() {
         println!("No source ports found.");
     } else {
         println!("Source ports: ");
@@ -21,7 +21,7 @@ pub fn print() -> Result<(), Errors> {
         });
     }
 
-    if output.ports().len() == 0 {
+    if output.ports().is_empty() {
         println!("No target ports found.");
     } else {
         println!("Target ports: ");

--- a/src/midi/devices.rs
+++ b/src/midi/devices.rs
@@ -82,7 +82,7 @@ fn find_input_port(port_name: &str) -> Result<MidiInputPort, Errors> {
         .ports()
         .into_iter()
         .find(|port| input.port_name(port) == Ok(port_name.to_string()))
-        .ok_or(Errors::InvalidInputPort(port_name.to_string()))
+        .ok_or(Errors::InvalidSourcePort(port_name.to_string()))
 }
 
 fn find_output_port(port_name: &str) -> Result<MidiOutputPort, Errors> {
@@ -92,5 +92,5 @@ fn find_output_port(port_name: &str) -> Result<MidiOutputPort, Errors> {
         .ports()
         .into_iter()
         .find(|port| output.port_name(port) == Ok(port_name.to_string()))
-        .ok_or(Errors::InvalidOutputPort(port_name.to_string()))
+        .ok_or(Errors::InvalidTargetPort(port_name.to_string()))
 }


### PR DESCRIPTION
I thought returning Result<(), Errors> from `fn main()` would automatically use our `impl Display for Errors`. That's not the case, errors handled this way result in the runtime's string representation getting outputted. A better idiom is to `eprintln!` any errors, and explicitly return an exit code that we control instead.

Also refactors to rename the error names to match the user-facing parameters.