### PR TITLE
feat: shrink app argument names

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ I use this when producing and jamming, maybe come up with a little swiss
 knife type thing. Other than that, a few enhancements that I am
 considering at the moment - keeping in mind this is a learning project:
 
+- Port aliasing to work around platform-dependent MIDI port names, making
+  scripts portable across machines. See [docs/port-naming.md](docs/port-naming.md).
+
 - An interactive mode, with maybe a ncurses-based TUI (do people still
   use that these days?) where you can just navigate with the keyboard to
   create routings.

--- a/docs/port-naming.md
+++ b/docs/port-naming.md
@@ -1,0 +1,35 @@
+# Port naming
+
+Port naming of class-compliant devices is confusing and platform-dependent.
+
+macOS seems to enumerate device outs as inputs (and ins as outputs), while
+Linux names both ports as ins.
+
+## Examples
+
+`midi-tool list` on macOS when I connect my Roland S-1:
+
+```
+Source ports:
+0: IAC Driver Bus 1
+1: S-1 MIDI OUT
+Target ports:
+0: IAC Driver Bus 1
+1: S-1 MIDI IN
+```
+
+And on my Raspberry Pi:
+
+```
+Source ports:
+0: Midi Through:Midi Through Port-0 14:0
+1: S-1:S-1 MIDI IN 28:0
+Target ports:
+0: Midi Through:Midi Through Port-0 14:0
+1: S-1:S-1 MIDI IN 28:0
+```
+
+## Implications
+
+Scripts using this tool are not portable with the current exact-match search
+logic.

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,11 +20,11 @@ enum Commands {
     Route {
         /// Output port name
         #[arg(short, long)]
-        target_name: String,
+        target: String,
 
         /// Input port name
         #[arg(short, long)]
-        source_name: String,
+        source: String,
 
         /// Also print messages sent to the output.
         #[arg(short, long)]
@@ -35,7 +35,7 @@ enum Commands {
     Monitor {
         /// Input port name
         #[arg(short, long)]
-        source_name: String,
+        source: String,
     },
 }
 
@@ -66,10 +66,10 @@ fn main() -> std::process::ExitCode {
     if let Err(e) = match args.command {
         Commands::List => devices::print(),
         Commands::Route {
-            source_name,
-            target_name,
+            source,
+            target,
             verbose,
-        } => devices::route(source_name, target_name, verbose),
+        } => devices::route(source, target, verbose),
         Commands::Monitor { source } => devices::monitor(source),
     } {
         eprintln!("{}", e);

--- a/src/midi/devices.rs
+++ b/src/midi/devices.rs
@@ -37,34 +37,38 @@ pub fn print() -> Result<(), Errors> {
     Ok(())
 }
 
-pub fn route(source_name: String, target_name: String, verbose: bool) -> Result<(), Errors> {
-    let source = find_input_port(&source_name)?;
-    let target = find_output_port(&target_name)?;
+pub fn route(source: String, target: String, verbose: bool) -> Result<(), Errors> {
+    let source_port = find_source_port(&source)?;
+    let target_port = find_target_port(&target)?;
 
-    let targets: Vec<Box<dyn Target>> = if verbose {
+    let route_targets: Vec<Box<dyn Target>> = if verbose {
         vec![
-            Box::new(OutputTarget::new(target_name, target)),
-            Box::new(MonitorTarget::new(source_name.to_string())),
+            Box::new(OutputTarget::new(target, target_port)),
+            Box::new(MonitorTarget::new(source.to_string())),
         ]
     } else {
-        vec![Box::new(OutputTarget::new(target_name, target))]
+        vec![Box::new(OutputTarget::new(target, target_port))]
     };
 
-    let target_names: String = targets
+    let target_names: String = route_targets
         .iter()
         .filter_map(|target| target.describe())
         .collect::<Vec<String>>()
         .join(", ");
 
     println!("Activating route:");
-    println!("  Source: {}", source_name);
+    println!("  Source: {}", source);
     println!("  Target(s): {}", target_names);
 
-    Route { source, targets }.activate()
+    Route {
+        source: source_port,
+        targets: route_targets,
+    }
+    .activate()
 }
 
 pub fn monitor(source_name: String) -> Result<(), Errors> {
-    let source = find_input_port(&source_name)?;
+    let source = find_source_port(&source_name)?;
 
     println!("Monitoring source port: {}", source_name);
 
@@ -75,7 +79,7 @@ pub fn monitor(source_name: String) -> Result<(), Errors> {
     .activate()
 }
 
-fn find_input_port(port_name: &str) -> Result<MidiInputPort, Errors> {
+fn find_source_port(port_name: &str) -> Result<MidiInputPort, Errors> {
     let input = MidiInput::new("midi-tool").map_err(|_| Errors::InitFailure)?;
 
     input
@@ -85,7 +89,7 @@ fn find_input_port(port_name: &str) -> Result<MidiInputPort, Errors> {
         .ok_or(Errors::InvalidSourcePort(port_name.to_string()))
 }
 
-fn find_output_port(port_name: &str) -> Result<MidiOutputPort, Errors> {
+fn find_target_port(port_name: &str) -> Result<MidiOutputPort, Errors> {
     let output = MidiOutput::new("midi-tool").map_err(|_| Errors::InitFailure)?;
 
     output


### PR DESCRIPTION
- --source is nicer than --source-name
- introduce docs/port-naming.md to document port naming issues identified during testing